### PR TITLE
avoid blocking when to close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ngaut/pools
 
-go 1.17
+go 1.16
 
 require go.uber.org/atomic v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ngaut/pools
+
+go 1.17
+
+require go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/resource_pool.go
+++ b/resource_pool.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	atomicutil "go.uber.org/atomic"
+	"go.uber.org/atomic"
 )
 
 var (
@@ -31,12 +31,12 @@ type Resource interface {
 type ResourcePool struct {
 	resources   chan resourceWrapper
 	factory     Factory
-	capacity    atomicutil.Int64
-	idleTimeout atomicutil.Duration
+	capacity    atomic.Int64
+	idleTimeout atomic.Duration
 
 	// stats
-	waitCount atomicutil.Int64
-	waitTime  atomicutil.Duration
+	waitCount atomic.Int64
+	waitTime  atomic.Duration
 }
 
 type resourceWrapper struct {
@@ -56,8 +56,8 @@ func NewResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Dur
 	rp := &ResourcePool{
 		resources:   make(chan resourceWrapper, maxCap),
 		factory:     factory,
-		capacity:    *atomicutil.NewInt64(int64(capacity)),
-		idleTimeout: *atomicutil.NewDuration(idleTimeout),
+		capacity:    *atomic.NewInt64(int64(capacity)),
+		idleTimeout: *atomic.NewDuration(idleTimeout),
 	}
 	for i := 0; i < capacity; i++ {
 		rp.resources <- resourceWrapper{}

--- a/roundrobin_test.go
+++ b/roundrobin_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPool(t *testing.T) {
-	lastId.Set(0)
+	lastId.Store(0)
 	p := NewRoundRobin(5, time.Duration(10e9))
 	p.Open(PoolFactory)
 	defer p.Close()


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

ref https://github.com/pingcap/tidb/issues/31966

* replace ngaut/sync2 with uber/atomic. So TiDB can remove a dependency
* add go.mod